### PR TITLE
fix: parse ncu grouped output format

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -147,6 +147,47 @@ const mock = {
  @query-doctor/pglite  Not found`,
   },
 
+  groupedFormat: {
+    input: `Checking /Users/veksen/Work/query-doctor/Site/package.json
+
+Patch   Backwards-compatible bug fixes
+ turbo  ^2.10.6  →  ^2.10.7
+
+Minor   Backwards-compatible features
+ oxlint  ^1.70.0  →  ^1.76.0
+ vite     ^8.1.5  →   ^8.2.0
+
+Major   Potentially breaking API changes
+ npm         11.13.0  →  12.0.2
+ typescript   ^5.6.3  →  ^7.0.2
+
+Major version zero   Anything may change
+ @tsdown/css  0.22.13  →  0.22.14
+
+Run npx npm-check-updates --deep -u to upgrade package.json
+
+Checking /Users/veksen/Work/query-doctor/Site/apps/blog/package.json
+
+ @query-doctor/pglite  Not found
+
+Run npx npm-check-updates --deep -u to upgrade apps/blog/package.json`,
+    libraries: [
+      "turbo 2.10.6 → 2.10.7",
+      "oxlint 1.70.0 → 1.76.0",
+      "vite 8.1.5 → 8.2.0",
+      "npm 11.13.0 → 12.0.2",
+      "typescript 5.6.3 → 7.0.2",
+      "@tsdown/css 0.22.13 → 0.22.14",
+    ],
+  },
+
+  gibberish: {
+    input: `On branch main
+Your branch is up to date with 'origin/main'.
+
+nothing to commit, working tree clean`,
+  },
+
   prerelease: {
     input: ` @typescript/native-preview  7.0.0-dev.20260510.1  →  7.0.0-dev.20260511.1
  vitest                                    ^4.1.5  →                ^4.1.6`,
@@ -638,6 +679,41 @@ it("handles prerelease versions (e.g. 7.0.0-dev.20260510.1)", async () => {
 
   expect(input.value).toEqual(mock.prerelease.input)
   expect(output.value).toEqual(mock.prerelease.output.npm)
+})
+
+it("handles the grouped output format (ncu --format group)", async () => {
+  const { getByTestId, getAllByTestId, getByText } = render(<App />)
+
+  const input = getByTestId("input") as HTMLInputElement
+  const output = getByTestId("output") as HTMLInputElement
+
+  input.focus()
+  await userEvent.paste(mock.groupedFormat.input)
+
+  expect(output.value).not.toEqual(
+    "This doesn't look like a valid npx npm-check-updates output."
+  )
+
+  expect(getAllByTestId("library")).toHaveLength(
+    mock.groupedFormat.libraries.length
+  )
+  mock.groupedFormat.libraries.forEach((library) => {
+    expect(getByText(library)).toBeDefined()
+  })
+})
+
+it("shows a message on input that is not ncu output at all", async () => {
+  const { getByTestId } = render(<App />)
+
+  const input = getByTestId("input") as HTMLInputElement
+  const output = getByTestId("output") as HTMLInputElement
+
+  input.focus()
+  await userEvent.paste(mock.gibberish.input)
+
+  expect(output.value).toEqual(
+    "This doesn't look like a valid npx npm-check-updates output."
+  )
 })
 
 it("handles monorepo output with 'Not found' packages", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -125,21 +125,39 @@ function App() {
     return Array.from(uniqueLibraries.values())
   }
 
+  // ncu wraps the upgrade table in informational lines: the package.json being
+  // checked, group headings ("Patch   Backwards-compatible bug fixes"), packages
+  // it could not resolve, and the closing hint. Only upgrades carry the arrow.
+  const isUpgrade = (line: string): boolean => line.includes("→")
+
+  // Markers that identify the paste as ncu output even when it lists no upgrade.
+  const isNcuNotice = (line: string): boolean =>
+    [
+      "Checking ",
+      "Run npx npm-check-updates ",
+      "All dependencies match",
+      "No dependencies.",
+      "Not found",
+    ].some((marker) => line.includes(marker))
+
   const parseLibraries = (str: string): Library[] => {
-    if (!str) return []
+    if (!str.trim()) return []
 
     let output: Library[] = []
 
     try {
-      output = str
+      const lines = str
         .split(/\n/)
         .map((line) => line.trim())
-        .filter((line) => !line.startsWith("Run npx npm-check-updates "))
-        .filter((line) => !line.includes("Checking "))
-        .filter((line) => !line.includes("All dependencies match"))
-        .filter((line) => !line.includes("No dependencies."))
-        .filter((line) => !line.includes("Not found"))
         .filter(Boolean)
+
+      const upgrades = lines.filter(isUpgrade)
+
+      if (!upgrades.length && !lines.some(isNcuNotice)) {
+        throw Error("invalid output")
+      }
+
+      output = upgrades
         .map((line): Library => {
           const [name, versionFrom, , versionTo] = line.split(/ +/)
           return {


### PR DESCRIPTION
## Problem

Pasting output from `npm-check-updates` produced "This doesn't look like a valid npx npm-check-updates output." instead of any commands.

ncu prints a bare heading line above each table:

```
Patch   Backwards-compatible bug fixes
Minor   Backwards-compatible features
Major   Potentially breaking API changes
Major version zero   Anything may change
```

The parser filtered a blacklist of known informational lines (`Checking `, `Run npx …`, `Not found`) and treated every remaining line as `name from → to`. So `Patch   Backwards-compatible bug fixes` parsed as name `Patch`, from `Backwards-compatible`, to `fixes`. That failed `validateVersion`, which throws, and one bad line discards the entire paste.

The headings come from [`version-util.ts:221-226`](https://github.com/raineorshine/npm-check-updates/blob/main/src/lib/version-util.ts#L221). The same code path emits arbitrary group names when a user sets `groupFunction`, so adding the four known headings to the blacklist would not hold.

## Change

Only lines containing `→` describe an upgrade. Everything else is informational and ignored. The blacklist is gone.

An arrow whitelist on its own would make a random paste return nothing instead of erroring, so a paste with zero arrow lines now errors unless it carries a recognizable ncu notice. A run that legitimately has nothing to upgrade (`All dependencies match the latest package versions :)`, `No dependencies.`) still shows empty output rather than an error.

The early return also changed from `!str` to `!str.trim()`, so a whitespace-only input does not trip the new check.

## Verification

A 178-line monorepo paste across 14 `package.json` files now yields 33 unique libraries and the full command chain. `typescript`, `@types/node`, `drizzle-orm`, `drizzle-kit`, `vite`, `postcss`, `astro`, `framer-motion`, `tsdown` and `@base-ui/react` each dedupe to one bump despite appearing in several packages.

Two tests added: the grouped format with headings, a `Not found` package and several `Checking` blocks, plus a `git status` paste pinning the invalid-input error. 27 tests pass, along with oxlint, oxfmt and `tsc --noEmit`.

## Not covered

ncu also prints `Ignored incompatible updates (peer dependencies):` sections whose entries carry arrows, so those get read as upgrades. That behaviour predates this change and the reported paste did not include such a section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)