### PR TITLE
feat: add --force checkbox

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -43,6 +43,19 @@ const mock = {
     },
   },
 
+  force: {
+    input: ` react              ^16.8.6  →  ^17.0.1
+    react-dom          ^16.8.6  →  ^17.0.1
+    react-scripts        3.0.1  →    4.0.1
+    typescript          ^3.5.3  →   ^4.1.2
+    @types/react      ^16.8.23  →  ^17.0.0
+    @types/react-dom   ^16.8.5  →  ^17.0.0`,
+    output: {
+      npm: `npx npm-check-updates -u react; npm i --force; git add -A; git commit -m "chore(deps): bump react to 17.0.1"; npx npm-check-updates -u react-dom; npm i --force; git add -A; git commit -m "chore(deps): bump react-dom to 17.0.1"; npx npm-check-updates -u react-scripts; npm i --force; git add -A; git commit -m "chore(deps): bump react-scripts to 4.0.1"; npx npm-check-updates -u typescript; npm i --force; git add -A; git commit -m "chore(deps): bump typescript to 4.1.2"; npx npm-check-updates -u @types/react; npm i --force; git add -A; git commit -m "chore(deps): bump @types/react to 17.0.0"; npx npm-check-updates -u @types/react-dom; npm i --force; git add -A; git commit -m "chore(deps): bump @types/react-dom to 17.0.0"`,
+      yarn: `npx npm-check-updates -u react; yarn --force; git add -A; git commit -m "chore(deps): bump react to 17.0.1"; npx npm-check-updates -u react-dom; yarn --force; git add -A; git commit -m "chore(deps): bump react-dom to 17.0.1"; npx npm-check-updates -u react-scripts; yarn --force; git add -A; git commit -m "chore(deps): bump react-scripts to 4.0.1"; npx npm-check-updates -u typescript; yarn --force; git add -A; git commit -m "chore(deps): bump typescript to 4.1.2"; npx npm-check-updates -u @types/react; yarn --force; git add -A; git commit -m "chore(deps): bump @types/react to 17.0.0"; npx npm-check-updates -u @types/react-dom; yarn --force; git add -A; git commit -m "chore(deps): bump @types/react-dom to 17.0.0"`,
+    },
+  },
+
   withMinor: {
     input: ` react              ^16.8.6  →  ^17.0.1
     react-dom          ^16.8.6  →  ^17.0.1
@@ -503,6 +516,24 @@ it("makes it possible to deep/recursive upgrade", async () => {
 
   expect(input.value).toEqual(mock.deep.input)
   expect(output.value).toEqual(mock.deep.output.npm)
+})
+
+it("makes it possible to force the install", async () => {
+  const { getByTestId } = render(<App />)
+
+  const input = getByTestId("input") as HTMLInputElement
+  const output = getByTestId("output") as HTMLInputElement
+  const force = getByTestId("force") as HTMLLabelElement
+  const forceCheckbox = getByTestId("force-checkbox") as HTMLInputElement
+
+  force.click()
+  input.focus()
+  await userEvent.paste(mock.force.input)
+
+  expect(forceCheckbox.checked).toBeTruthy()
+
+  expect(input.value).toEqual(mock.force.input)
+  expect(output.value).toEqual(mock.force.output.npm)
 })
 
 it("restores disabled libraries from localstorage", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ function App() {
     false
   )
   const [deep, setDeep] = useLocalStorage<boolean>("deep", false)
+  const [force, setForce] = useLocalStorage<boolean>("force", false)
 
   useEffect(() => {
     if (!input.trim()) {
@@ -190,7 +191,12 @@ function App() {
       return ""
     }
 
-    const install = packageManager === "npm" ? "npm i" : "yarn"
+    const install = [
+      packageManager === "npm" ? "npm i" : "yarn",
+      force ? "--force" : "",
+    ]
+      .join(" ")
+      .trim()
     const lockfile =
       packageManager === "npm" ? "package-lock.json" : "yarn.lock"
 
@@ -205,9 +211,14 @@ function App() {
         deep ? "--deep" : "",
       ].join(" ")
 
+      const installCommand = [
+        packageManager === "npm" ? "npm i" : "yarn",
+        force ? "--force" : "",
+      ].join(" ")
+
       const command = [
         ncuCommand,
-        packageManager === "npm" ? "npm i" : "yarn",
+        installCommand,
         `git add -A`,
         `git commit -m "chore(deps): bump ${name} to ${to}"`,
       ]
@@ -357,6 +368,23 @@ function App() {
             onChange={() => setDeep((prevValue) => !prevValue)}
           >
             --deep
+          </Option>
+
+          <div
+            className="section-title cursor-help"
+            title={`Forces the install through peer dependency conflicts. Will run ${
+              packageManager === "npm" ? "npm i" : "yarn"
+            } --force.`}
+          >
+            Force install [?]
+          </div>
+          <Option
+            data-testid="force"
+            value="force"
+            checked={force}
+            onChange={() => setForce((prevValue) => !prevValue)}
+          >
+            --force
           </Option>
         </div>
 


### PR DESCRIPTION
Adds a `--force` checkbox below `--deep`. When it is on, the generated install step becomes `npm i --force` (or `yarn --force`), for upgrades that need to get past a peer dependency conflict. It applies to the per-library install and to the lockfile bump. The setting persists to localStorage like the other options. A new test mirrors the existing `--deep` one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)